### PR TITLE
return the encoded data instead of printing directly. This way we can…

### DIFF
--- a/connectors/php/BaseFilemanager.php
+++ b/connectors/php/BaseFilemanager.php
@@ -330,10 +330,9 @@ abstract class BaseFilemanager
             }
         }
 
-        echo json_encode([
+        return json_encode([
             'data' => $response,
         ]);
-        exit;
     }
 
     protected function setParams()

--- a/connectors/php/filemanager.php
+++ b/connectors/php/filemanager.php
@@ -45,4 +45,4 @@ $fm = Fm::app()->getInstance($config);
 // example to set list of allowed actions
 //$fm->setAllowedActions(["select", "move"]);
 
-$fm->handleRequest();
+echo $fm->handleRequest();


### PR DESCRIPTION
So this might be a bit of a harder request to get merged. But the main idea is that we use another layer before we pass the request to filemanager connector. We have Silex first, than pass the request to the filemanager. But because `handleRequest` echo's the data, we get erros about the header already being send. So we have to wrap the method call 
```php
ob_start();
$fm->handleRequest();
$response = ob_get_contents();
ob_end_clean();
```

This could be fixed if the `handleRequest` just would return the data and not echo it. Than the connector `filemanager.php` can echo it. Or in oure case make the controller return the data.