### PR TITLE
Bugfix: Not loading userfiles folder when it's empty

### DIFF
--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -2494,7 +2494,7 @@ $.richFilemanagerPlugin = function(element, pluginOptions)
 		};
 
 		// shift parent item to unshift it back after sorting
-		if (items[0].rdo.type === 'parent') {
+		if (items[0] && items[0].rdo.type === 'parent') {
             parentItem = items.shift();
 		}
 


### PR DESCRIPTION
Fixes error 'Uncaught TypeError: Cannot read property 'rdo' of undefined' when the userfiles folder is empty.