### PR TITLE
Initial commit of new security model.

### DIFF
--- a/connectors/php/LocalUploadHandler.php
+++ b/connectors/php/LocalUploadHandler.php
@@ -28,7 +28,7 @@ class LocalUploadHandler extends BaseUploadHandler
         $this->options['param_name'] = 'files';
         $this->options['readfile_chunk_size'] = 10 * 1024 * 1024;
         $this->options['max_file_size'] = $this->fm->config['upload']['fileSizeLimit'];
-        // BaseFilemanager::is_allowed_file_type() is used instead of this regex check
+        // BaseFilemanager::check_write_permission() is used instead of this regex check
         $this->options['accept_file_types'] = '/.+$/i';
         // no need to override, this list fits for images handling libs
         $this->options['image_file_types'] = '/\.(gif|jpe?g|png)$/i';
@@ -104,11 +104,7 @@ class LocalUploadHandler extends BaseUploadHandler
             $file->error = $this->get_error_message('post_max_size');
             return false;
         }
-        if (!$this->fm->is_allowed_file_type($file->name)) {
-            $file->error = $this->get_error_message('accept_file_types');
-            return false;
-        }
-        if(!$this->fm->is_allowed_name($file->name, false)) {
+        if(!$this->fm->is_unrestricted($file->name, false)) {
             $file->error = ['FORBIDDEN_NAME', [$file->name]];
             return false;
         }

--- a/connectors/php/application/FmApplication.php
+++ b/connectors/php/application/FmApplication.php
@@ -38,7 +38,7 @@ class FmApplication {
             $fm = new LocalFilemanager($configuration);
         }
 
-        if(!auth()) {
+        if(!fm_authenticate()) {
             $fm->error('AUTHORIZATION_REQUIRED');
         }
 

--- a/connectors/php/config.php
+++ b/connectors/php/config.php
@@ -66,80 +66,67 @@ $config = [
          * PHP requires INTL extension installed, otherwise all non-latin characters will be stripped.
          */
         "charsLatinOnly" => false,
-        /**
-         * Default value "false".
-         * Means all capabilities handled by the application are available.
-         * You can set only some ot them as array to restrict the allowed actions.
-         * For the full list of capabilities @see BaseFilemanager::actions_list
-         */
-        "capabilities" => false,
-        /**
-         * Default value "false".
-         * Allow users to download a Zip archive of a specific folder and contents (including subfolders).
-         */
-        "allowFolderDownload" => false,
     ],
     /**
      * Security section
      */
     "security" => [
+        /* Set `read_only` to true to disable all modifications to the filesystem, including thumbnail generation. */
+        "read_only" => true,
         /**
-         * Default value "false".
-         * If set to "true", allow users to upload file with no extension.
+         * Restrictions based on file name: "extensions", and "patterns" (glob matching, like shell wildcards).
+         *
+         * Files or directories that match these lists will be filtered from directory listing results, and 
+         * will be restricted from all file operations (both read and write).
+         *
+         * Set 'policy' to "DISALLOW_LIST" to blacklist, or "ALLOW_LIST" to whitelist, the 'restrictions' array.
          */
-        "allowNoExtension" => false,
+        "extensions" => [
+            /* Filename extensions from PATHINFO_EXTENSION are compared against this list, after the right-most dot '.'.
+             * To disallow empty/no extensions like the old `allowNoExtension` option, add the empty string "" to this list. 
+             */
+            "policy" => "DISALLOW_LIST", 
+            "ignorecase" => true, 
+            "restrictions" => [
+                "php",
+                "asp",
+                "pl",
+                "py",
+                "rb",
+                "key",
+                "conf",
+            ],
+        ],
+        
+        "patterns" => [
+            /* These globs are compared against PATHINFO_BASENAME, so they will match in any directory. */
+            "policy" => "DISALLOW_LIST", 
+            "ignorecase" => true, 
+            "restrictions" => [
+                ".htaccess",
+                "web.config",
+                "*config",
+                "*conf",
+                "*cnf",
+                "*passwd",
+                "*pass",
+                "*group",
+                "*groups",
+                "id_*",
+                "*key",
+                "*keys",
+                "*pub",
+                "magic",
+                "*hosts",
+                "_thumbs",  // FIXME: This breaks the current thumb permission code.
+                ".CDN_ACCESS_LOGS",
+            ],
+        ],
         /**
          * Default value "true".
          * Sanitize file/folder name, replaces gaps and some other special chars.
          */
         "normalizeFilename" => true,
-        /**
-         * Array of file names excluded from listing.
-         */
-        "excluded_files" => [
-            ".htaccess",
-            "web.config",
-        ],
-        /**
-         * Array of folder names excluded from listing.
-         */
-        "excluded_dirs" => [
-            "_thumbs",
-            ".CDN_ACCESS_LOGS",
-        ],
-        /**
-         * Files excluded from listing, using REGEX.
-         */
-        "excluded_files_REGEXP" => "/^\\./",
-        /**
-         * Folders excluded from listing, using REGEX.
-         */
-        "excluded_dirs_REGEXP" => "/^\\./",
-        /**
-         * Array of files extensions permitted for editing.
-         */
-        "editRestrictions" => [
-            "txt",
-            "csv",
-            "md",
-        ],
-    ],
-    /**
-     * File types that are filtered out from the output list based on the type of filter ('getfolder' request)
-     */
-    "outputFilter" => [
-        /**
-         * File types to be filtered out for "images" filter
-         */
-        "images" => [
-            "jpg",
-            "jpe",
-            "jpeg",
-            "gif",
-            "png",
-            "svg",
-            "bmp",
-        ],
     ],
     /**
      * Upload section
@@ -156,53 +143,6 @@ $config = [
          * If set to "true" files will be overwritten on uploads if they have same names, otherwise an index will be added.
          */
         "overwrite" => false,
-        /**
-         * Default value "false".
-         * If set to "true", only images are accepted for upload.
-         */
-        "imagesOnly" => false,
-        /**
-         * Default value "DISALLOW_ALL". Takes value "ALLOW_ALL" / "DISALLOW_ALL".
-         * If is set to "DISALLOW_ALL", only files with extensions contained in `restrictions` array will be allowed.
-         * If is set to "ALLOW_ALL", all files will be accepted for upload except for files with extensions contained in `restrictions`.
-         */
-        "policy" => "DISALLOW_ALL",
-        /**
-         * Array of files extensions permitted for uploading/creating
-         */
-        "restrictions" => [
-            "jpg",
-            "jpe",
-            "jpeg",
-            "gif",
-            "png",
-            "svg",
-            "txt",
-            "pdf",
-            "odp",
-            "ods",
-            "odt",
-            "rtf",
-            "doc",
-            "docx",
-            "xls",
-            "xlsx",
-            "ppt",
-            "pptx",
-            "csv",
-            "ogv",
-            "avi",
-            "mkv",
-            "mp4",
-            "webm",
-            "m4v",
-            "ogg",
-            "mp3",
-            "wav",
-            "zip",
-            "rar",
-            "md",
-        ],
     ],
     /**
      * Images section

--- a/connectors/php/filemanager.php
+++ b/connectors/php/filemanager.php
@@ -17,13 +17,62 @@
 require_once('application/Fm.php');
 require_once('application/FmHelper.php');
 
-function auth()
+
+// This function is called for every server connection. It must return true.
+//
+// Implement this function to authenticate the user, for example to check a 
+// password login, or restrict client IP address.
+// 
+// This function only authorizes the user to connect and/or load the initial page. 
+// Authorization for individual files or dirs is provided by the two functions below.
+// 
+// NOTE: If this function returns false, the user will simply see an error. It 
+// probably makes more sense to redirect the user to a login page instead.
+//
+// NOTE: If using session variables, the session must be started first (session_start()).
+function fm_authenticate()
 {
-    // IMPORTANT : by default Read and Write access is granted to everyone.
-    // You can insert your own code over here to check if the user is authorized.
-    // If you use a session variable, you've got to start the session first (session_start())
+    // Customize this code as desired.
     return true;
 }
+
+
+// This function is called before any filesystem read operation, where 
+// $filepath is the file or directory being read. It must return true,
+// otherwise the read operation will be denied.
+//
+// Implement this function to do custom individual-file permission checks, such as
+// user/group authorization from a database, or session variables, or any other custom logic.
+//
+// Note that this is not the only permissions check that must pass. The read operation
+// must also pass
+//   * Filesystem permissions (if any), e.g. POSIX `rwx` permissions on Linux
+//   * The filepath must be allowed according to config['patterns'] and config['extensions']
+//
+function fm_has_write_permission($filepath) {
+    // Customize this code as desired.
+    return true;
+}
+
+
+// This function is called before any filesystem write operation, where 
+// $filepath is the file or directory being written to. It must return true,
+// otherwise the write operation will be denied.
+//
+// Implement this function to do custom individual-file permission checks, such as
+// user/group authorization from a database, or session variables, or any other custom logic.
+//
+// Note that this is not the only permissions check that must pass. The write operation
+// must also pass
+//   * Filesystem permissions (if any), e.g. POSIX `rwx` permissions on Linux
+//   * The filepath must be allowed according to config['patterns'] and config['extensions']
+//   * config['read_only'] must be set to false, otherwise all writes are disabled
+//
+function fm_has_read_permission($filepath) {
+    // Customize this code as desired.
+    return true;
+}
+
 
 $config = array();
 

--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
 							<h1 data-bind="text: rdo().attributes.name, attr: {title: rdo().id}"></h1>
 							<div class="fm-preview-title-controls">
 								<a href="#" class="btn-copy-url" data-bind="attr: {title: $root.lg().copy_to_clipboard, 'data-clipboard-text': viewer.pureUrl()}"></a>
-								<!-- ko if: viewer.isEditable() && !editor.enabled() -->
+								<!-- ko if: viewer.isEditable() && !editor.enabled() && viewer.options().is_writable -->
 								<a href="#" class="btn-editor-open" data-bind="attr: {title: $root.lg().editor_edit}, click: editFile"></a>
 								<!-- /ko -->
 								<!-- ko if: viewer.isEditable() && editor.enabled() -->


### PR DESCRIPTION
This commit has several major changes which are not backwards compatible.

Remove old permissions functions:

* Remove is_allowed_file_type
* Remove is_allowed_name
* Remove filter_output
* Remove hasPermission
* Remove has_system_permission
* Remove is_editable

Remove now-unused config options:

* Remove excluded_files
* Remove excluded_dirs
* Remove excluded_files_REGEXP
* Remove excluded_dirs_REGEXP
* Remove outputFilter
* Remove restrictions
* Remove actions_list
* Remove allowNoExtension
* Remove editRestrictions

Add new security config options:

* security.read_only
* security.extensions.policy
* security.extensions.ignorecase
* security.extensions.restrictions
* security.patterns.policy
* security.patterns.ignorecase
* security.patterns.restrictions

Add new permissions functions:

* check_write_permission
* check_read_permission
* has_write_permission
* has_read_permission
* has_system_write_permission
* has_system_read_permission
* is_unrestricted
* Rename auth to fm_authenticate to clarify meaning  (user callback)
* fm_has_write_permission  (user callback)
* fm_has_read_permission  (user callback)

Add new functionality:

* Server: For every action which has a filename, check r or w permission consistently
* Client: Examine read_only to set client browseOnly mode
* Client: Make a text file editable based on its boolean 'writable' attribute
* Client: Honor security.extensions for allowable file types