### PR TITLE
Fix URL for docs.google.com

### DIFF
--- a/scripts/filemanager.js
+++ b/scripts/filemanager.js
@@ -903,7 +903,7 @@ $.richFilemanagerPlugin = function(element, pluginOptions)
                 }
                 if(isGoogleDocsFile(filename) && config.viewer.google.enabled === true) {
                     viewerObject.type = 'google';
-                    viewerObject.url = 'http://docs.google.com/viewer?url=' + encodeURIComponent(createPreviewUrl(resourceObject, false)) + '&embedded=true';
+                    viewerObject.url = 'https://docs.google.com/viewer?url=' + encodeURIComponent(createPreviewUrl(resourceObject, false)) + '&embedded=true';
                     viewerObject.options = {
                         width: config.viewer.google.readerWidth,
                         height: config.viewer.google.readerHeight


### PR DESCRIPTION
In the filemanager.js file, at line 906, the Google viewer is accessed using HTTP:

`ViewerObject.url = 'http://docs.google.com/viewer?url=' + encodeURIComponent (createPreviewUrl (resourceObject, false)) + '& embedded = true';`

Due to this when using the RichFilemanager in servers that force the use of HTTPS can occur problems in the visualization like the one below:

`Mixed Content: The page at 'https://fm.svc.daspanel.site/' was loaded over HTTPS, but requested an insecure resource 'http://docs.google.com/viewer?url=https%3A%2F%2Ffm.svc.daspanel.site%2Fconn…_condominio_Abner_L._01_Q._51-FB.docx%26time%3D1501967130794&embedded=true'. This request has been blocked; the content must be served over HTTPS.`

