### PR TITLE
Close preview on node click

### DIFF
--- a/src/js/filemanager.js
+++ b/src/js/filemanager.js
@@ -1556,12 +1556,14 @@ $.richFilemanagerPlugin = function(element, pluginOptions)
 
             this.nodeClick = function(node, e) {
                 if(!config.manager.dblClickOpen) {
+                    model.previewModel.closePreview();
                     tree_node.openNode(node, true);
                 }
             };
 
             this.nodeDblClick = function(node, e) {
                 if(config.manager.dblClickOpen) {
+                    model.previewModel.closePreview();
                     tree_node.openNode(node, true);
                 }
             };


### PR DESCRIPTION
When you click on a node in the left hand panel, this modification will close any preview in the right hand panel.

Just as a comment - I'm not sure whether as part of a PR whether you'd like contributors to run the grunt task to create the minimised files or not? When I did this, it modified several files I haven't touched.